### PR TITLE
Use std::chrono::time_point instead of time_t

### DIFF
--- a/include/Watchdog.h
+++ b/include/Watchdog.h
@@ -115,7 +115,7 @@ public:
         watchImpl( ci::fs::path() );
     }
     //! Sets the last modification time of a file or directory. by default sets the time to the current time
-    static void touch( const ci::fs::path &path, std::time_t time = std::time( nullptr ) )
+    static void touch( const ci::fs::path &path, ci::fs::file_time_type time = ci::fs::file_time_type::clock::now() )
     {
         
         // if the file or directory exists change its last write time
@@ -384,7 +384,7 @@ protected:
         bool hasChanged( const ci::fs::path &path )
         {
             // get the last modification time
-            std::time_t time = ci::fs::last_write_time( path );
+            auto time = ci::fs::last_write_time( path );
             // add a new modification time to the map
             std::string key = path.string();
             if( mModificationTimes.find( key ) == mModificationTimes.end() ) {
@@ -405,7 +405,7 @@ protected:
         std::string                                             mFilter;
         std::function<void(const ci::fs::path&)>                mCallback;
         std::function<void(const std::vector<ci::fs::path>&)>   mListCallback;
-        std::map< std::string, time_t >                         mModificationTimes;
+        std::map< std::string, ci::fs::file_time_type >         mModificationTimes;
     };
     
     friend class SleepyWatchdog;


### PR DESCRIPTION
Previously `Watchdog.h` didn't compile in vc2015 due to `std::chrono::time_point` not being implicitly convertible to/from time_t. since `ci::fs::last_write_time()` takes and returns time_points I think it makes sense to use that type for modification time storage since it removes the need to convert.

I've tested this on vc2015 against the latest Cinder/master.